### PR TITLE
Removed deprecated callback using with the promise one

### DIFF
--- a/notification-logger.js
+++ b/notification-logger.js
@@ -3,7 +3,7 @@
 	Notification.requestPermission();
 	// Get current notification icon
 	icon = "notifications.png"
-	
+
 	function modifyIcon(icon_path) {
 		logger.icon = icon_path;
 	}
@@ -15,12 +15,20 @@
 	  	} else if (Notification.permission === "granted") {
 			new Notification(title ,{body: body, icon: logger.icon});
 	    } else if (Notification.permission !== 'denied') {
-	    	Notification.requestPermission(function (permission) {
+			Notification.requestPermission().then(function(result) {
+				if (result === 'denied') {
+					console.log('Permission wasn\'t granted. Allow a retry.');
+					return;
+				}
+				if (result === 'default') {
+					console.log('The permission request was dismissed.');
+					return;
+				}
 				if (permission === "granted") {
 					new Notification(title ,{body: body});
 				}
-	    });
-	  }
+			});
+	  	}
 	}
 
 	function originalFnCallDecorator(fn, fnName) {


### PR DESCRIPTION
According to [this specs](https://developer.mozilla.org/ru/docs/Web/API/Notification/requestPermission) using with a callback method is deprecated, so better use promises.